### PR TITLE
timeseries4s: refactor to support undefined values

### DIFF
--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/TimeSeriesOps.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/TimeSeriesOps.scala
@@ -4,6 +4,8 @@ import com.twitter.util.Time
 import dev.enbnt.timeseries.common.DataPoint
 import dev.enbnt.timeseries.common.Seekable
 import dev.enbnt.timeseries.common.TimeSeriesLike
+import dev.enbnt.timeseries.common.Value
+import scala.collection.Searching
 
 object TimeSeriesOps {
   implicit final class RichTimeSeries(val ts: TimeSeriesLike)
@@ -15,19 +17,40 @@ object TimeSeriesOps {
       else {
         val underlying: Iterable[DataPoint] = ts match {
           case seek: Seekable =>
-            val startIdx = seek.indexAt(begin)
-            val endIdx = seek.size.min(seek.indexAt(end) + 1)
-
-            ts.view.slice(startIdx, endIdx)
+            val startIdx: Int = idxFor(seek.indexAt(begin))
+            val endIdx: Int = seek.size.min(idxFor(seek.indexAt(end)) + 1)
+            ts.slice(startIdx, endIdx)
           case _ =>
             ts.dropWhile(_.time < begin).takeWhile(_.time <= end)
         }
 
         if (ts.isEmpty) TimeSeries.empty()
-        else TimeSeries(ts.interval, underlying)
+        else
+          TimeSeries(ts.interval, underlying)
       }
 
     }
+
+    def get(time: Time): Option[DataPoint] = {
+      ts match {
+        case seek: Seekable =>
+          seek.indexAt(time) match {
+            case Searching.Found(idx) =>
+              val dp = seek(idx)
+              if (dp.value == Value.Undefined) None else Some(dp)
+            case _ => None
+          }
+        case _ =>
+          ts.find(_.time == time)
+      }
+    }
+
+    private[this] def idxFor(searching: Searching.SearchResult): Int =
+      searching match {
+        case Searching.Found(idx)                     => idx
+        case Searching.InsertionPoint(idx) if idx > 0 => idx
+        case _ => -1 // special case at 0 index
+      }
   }
 
 }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/DataPoint.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/DataPoint.scala
@@ -1,11 +1,20 @@
 package dev.enbnt.timeseries.common
 
 import com.twitter.util.Time
+import dev.enbnt.timeseries.common.Value._
 
 private[timeseries] object DataPoint {
   implicit val timeOrdering: Ordering[DataPoint] = Ordering.by(_.time)
   implicit val valueOrdering: Ordering[DataPoint] = Ordering.by(_.value)
-  implicit val asPair: DataPoint => (Time, Double) = dp => (dp.time, dp.value)
+  implicit val asPair: DataPoint => (Time, Value) = dp => (dp.time, dp.value)
+
+  def apply(time: Time, value: Float): DataPoint =
+    DataPoint(time, value.asValue)
+  def apply(time: Time, value: Double): DataPoint =
+    DataPoint(time, value.asValue)
+  def apply(time: Time, value: Int): DataPoint = DataPoint(time, value.asValue)
+  def apply(time: Time, value: Long): DataPoint = DataPoint(time, value.asValue)
+
 }
 
 /**
@@ -16,4 +25,4 @@ private[timeseries] object DataPoint {
  * @param value
  *   The measured value of that data associated with the given [[time]]
  */
-private[timeseries] final case class DataPoint(time: Time, value: Double)
+private[timeseries] final case class DataPoint(time: Time, value: Value)

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Seekable.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Seekable.scala
@@ -1,6 +1,7 @@
 package dev.enbnt.timeseries.common
 
 import com.twitter.util.Time
+import scala.collection.Searching.SearchResult
 
 /**
  * A [[Seekable]] represents an indexable [[TimeSeriesLike]], which can be used
@@ -10,12 +11,15 @@ import com.twitter.util.Time
 private[timeseries] trait Seekable extends TimeSeriesLike {
 
   /**
-   * Retrieve the index which corresponds to the associated [[Time time]].
+   * Search for an index that corresponds to the given [[Time time]].
    * @param time
    *   The time to search for.
    * @return
-   *   The index associated with the given time, if it is found.
+   *   The [[SearchResult]] associated with the given time.
    */
-  def indexAt(time: Time): Int
+  def indexAt(time: Time): SearchResult
+
+  /** Return the [[DataPoint]] defined at the given index */
+  def apply(idx: Int): DataPoint
 
 }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Value.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Value.scala
@@ -1,0 +1,46 @@
+package dev.enbnt.timeseries.common
+import dev.enbnt.timeseries.common.Value.Undefined
+
+/** [[Value]] is a marker trait for Time Series value data. */
+sealed trait Value extends Any
+
+object Value {
+  implicit val ordering: Ordering[Value] = Ordering.by {
+    case FloatVal(v)  => v
+    case DoubleVal(v) => v
+    case LongVal(v)   => v
+    case IntVal(v)    => v
+    case Undefined    => Double.NaN
+  }
+
+  case class FloatVal(value: Float) extends AnyVal with Value
+  case class DoubleVal(value: Double) extends AnyVal with Value
+  case class IntVal(value: Int) extends AnyVal with Value
+  case class LongVal(value: Long) extends AnyVal with Value
+  case object Undefined extends Value
+
+  implicit class RichFloat(val value: Float) extends AnyVal {
+    def asValue: Value = if (value.isNaN) Undefined else FloatVal(value)
+  }
+
+  implicit class RichDouble(val value: Double) extends AnyVal {
+    def asValue: Value = if (value.isNaN) Undefined else DoubleVal(value)
+  }
+
+  implicit class RichInt(val value: Int) extends AnyVal {
+    def asValue: Value = IntVal(value)
+  }
+
+  implicit class RichLong(val value: Long) extends AnyVal {
+    def asValue: Value = LongVal(value)
+  }
+
+//  /**
+//   * @param t
+//   * @tparam T
+//   *
+//   * @note
+//   *   Struct types are always assumed to be unordered
+//   */
+//  case class Struct[T](value: T) extends AnyVal with Value
+}

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable/TimeSeries.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable/TimeSeries.scala
@@ -5,9 +5,11 @@ import com.twitter.util.Time
 import dev.enbnt.timeseries.common.DataPoint
 import dev.enbnt.timeseries.common.Seekable
 import dev.enbnt.timeseries.common.TimeSeriesLike
+import dev.enbnt.timeseries.common.Value
 import scala.collection.IndexedSeqOps
 import scala.collection.IndexedSeqView
 import scala.collection.Searching
+import scala.collection.Searching.SearchResult
 
 sealed trait TimeSeries extends TimeSeriesLike
 
@@ -16,14 +18,9 @@ object TimeSeries {
     data match {
       case e if e.isEmpty => EmptyTimeSeries
       case single if single.size == 1 =>
-        single.headOption match {
-          case Some(dp) =>
-            new DenseTimeSeries(interval, dp.time, IndexedSeq(dp.value))
-          case _ =>
-            throw new IllegalStateException(
-              s"Expected a valid time stamp but found $data"
-            )
-        }
+        val dp = single.head
+        if (dp.value == Value.Undefined) EmptyTimeSeries
+        else DenseTimeSeries(interval, single)
 
       case _ =>
         val size = data.size
@@ -45,29 +42,12 @@ object TimeSeries {
         }
 
         val span: Int =
-          ((end - start).inNanoseconds / interval.inNanoseconds).toInt
+          ((end - start).inNanoseconds / interval.inNanoseconds).toInt + 1
 
-        // TODO - this will only work when we support undefined values for a dense time series
-//        if (span < size / 2) {
-//          val (times, values) = data.unzip
-//          new SparseTimeSeries(
-//            interval,
-//            times.toIndexedSeq,
-//            values.toIndexedSeq
-//          )
-//        } else {
-//          new DenseTimeSeries(interval, start, data.map(_.value).toIndexedSeq)
-//        }
-
-        if (span == size) {
-          new DenseTimeSeries(interval, start, data.map(_.value).toIndexedSeq)
+        if (span < size / 2) {
+          SparseTimeSeries(interval, data)
         } else {
-          val (times, values) = data.unzip
-          new SparseTimeSeries(
-            interval,
-            times.toIndexedSeq,
-            values.toIndexedSeq
-          )
+          DenseTimeSeries(interval, data)
         }
 
     }
@@ -80,13 +60,24 @@ private[timeseries] case object EmptyTimeSeries
     extends TimeSeries
     with Seekable
     with IndexedSeqOps[DataPoint, Iterable, Iterable[DataPoint]] {
+
+  private[this] val NotFound: SearchResult = Searching.InsertionPoint(0)
+
   def interval: Duration = Duration.Undefined
   override def start: Time = Time.Bottom
   override def end: Time = Time.Top
   def apply(i: Int): DataPoint = throw new IndexOutOfBoundsException()
   override def toString(): String = "EmptyTimeSeries"
   override def length: Int = 0
-  override def indexAt(time: Time): Int = -1
+  override def indexAt(time: Time): SearchResult = NotFound
+}
+
+object SparseTimeSeries {
+  def apply(interval: Duration, data: Iterable[DataPoint]): SparseTimeSeries = {
+    val (times, values) = data.filterNot(_.value == Value.Undefined).unzip
+    require(times.nonEmpty)
+    new SparseTimeSeries(interval, times.toIndexedSeq, values.toIndexedSeq)
+  }
 }
 
 /**
@@ -98,28 +89,19 @@ private[timeseries] case object EmptyTimeSeries
  * @param times
  * @param values
  */
-private[timeseries] final class SparseTimeSeries(
+private[timeseries] final class SparseTimeSeries private (
   val interval: Duration,
   times: IndexedSeq[Time],
-  values: IndexedSeq[Double]
+  values: IndexedSeq[Value]
 ) extends TimeSeries
     with Seekable
     with IndexedSeq[DataPoint] { self =>
-
-  require(times.nonEmpty)
-  require(times.size == values.size)
 
   override def start: Time = times.head
   override def end: Time = times.last
   override def apply(i: Int): DataPoint = DataPoint(times(i), values(i))
   override def length: Int = values.length
-  override def indexAt(time: Time): Int = {
-    times.search(time) match {
-      case Searching.Found(idx)                     => idx
-      case Searching.InsertionPoint(idx) if idx > 0 => idx
-      case _ => -1 // special case at 0 index
-    }
-  }
+  override def indexAt(time: Time): SearchResult = times.search(time)
 
   override def view: IndexedSeqView[DataPoint] = new IndexedSeqView[DataPoint] {
     def length: Int = self.length
@@ -132,38 +114,87 @@ private[timeseries] final class SparseTimeSeries(
 
 }
 
-// TODO - we need to define and filter undefined values.
-// For now we make the assumption that all data points are
-// filled in
-private[timeseries] final class DenseTimeSeries(
+object DenseTimeSeries {
+
+  def apply(
+    interval: Duration,
+    iterable: Iterable[DataPoint]
+  ): DenseTimeSeries = {
+
+    // trim undefined values from the start and end of the iterable
+    val trimmed = iterable.filterNot(_.value == Value.Undefined)
+    require(trimmed.nonEmpty, "DenseTimeSeries must be non-empty")
+
+    val start = trimmed.head.time
+    val end = trimmed.last.time
+
+    val size: Int =
+      ((end - start).inNanoseconds / interval.inNanoseconds).toInt + 1
+
+    val ar = Array.fill[Value](size)(Value.Undefined)
+
+    var definedCount = 0
+    trimmed.foreach { dp =>
+      if (dp.value != Value.Undefined) {
+        val idx =
+          (start.until(dp.time).inNanoseconds / interval.inNanoseconds).toInt
+        ar(idx) = dp.value
+        definedCount += 1
+      }
+    }
+
+    new DenseTimeSeries(interval, start, ar, size - definedCount)
+  }
+
+}
+
+private[timeseries] final class DenseTimeSeries private (
   val interval: Duration,
   val start: Time,
-  values: IndexedSeq[Double]
+  values: IndexedSeq[Value],
+  undefinedCount: Int
 ) extends TimeSeries
     with Seekable
     with IndexedSeq[DataPoint] { self =>
 
-  require(values.nonEmpty)
+  override def apply(i: Int): DataPoint = DataPoint(timeAt(i), values(i))
+
+  override def length: Int = values.size - undefinedCount
+
+  /**
+   * Retrieve the index which corresponds to the associated [[Time time]].
+   *
+   * @param time
+   *   The time to search for.
+   * @return
+   *   The index associated with the given time, if it is found.
+   */
+  override def indexAt(time: Time): SearchResult = {
+    time match {
+      case t if t < start => Searching.InsertionPoint(0)
+      case t if t > end   => Searching.InsertionPoint(size)
+      case _ =>
+        val idx = ((time - start).inNanoseconds / interval.inNanoseconds).toInt
+        Searching.Found(idx)
+    }
+
+  }
+
+  override val end: Time = timeAt(values.length - 1)
 
   private[this] def timeAt(index: Int): Time =
     start + (interval * index)
 
-  override def apply(i: Int): DataPoint = DataPoint(timeAt(i), values(i))
+  override lazy val view: IndexedSeqView[DataPoint] = {
+    val data = values.zipWithIndex.collect {
+      case (value, idx) if value != Value.Undefined =>
+        DataPoint(timeAt(idx), value)
+    }.toIndexedSeq
 
-  override def length: Int = values.length
-
-  override def indexAt(time: Time): Int =
-    ((time - start).inNanoseconds / interval.inNanoseconds).toInt
-
-  override def end: Time = timeAt(values.length - 1)
-
-  override def view: IndexedSeqView[DataPoint] = new IndexedSeqView[DataPoint] {
-    def length: Int = self.length
-    def apply(i: Int): DataPoint = self(i)
+    new IndexedSeqView[DataPoint] {
+      def length: Int = data.length
+      def apply(i: Int): DataPoint = data(i)
+    }
   }
-
-  override def knownSize: Int = values.length
-
-  override def className = "DenseTimeSeries"
 
 }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable/TimeSeries.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable/TimeSeries.scala
@@ -5,6 +5,7 @@ import com.twitter.util.Time
 import dev.enbnt.timeseries.common.DataPoint
 import dev.enbnt.timeseries.common.Seekable
 import dev.enbnt.timeseries.common.TimeSeriesLike
+import dev.enbnt.timeseries.common.Value
 import dev.enbnt.timeseries.util.CircularBuffer
 import scala.collection.Searching
 
@@ -13,12 +14,17 @@ sealed trait TimeSeries extends TimeSeriesLike {
 
 }
 
-class CircularBufferTimeSeries(override val interval: Duration, capacity: Int)
-    extends CircularBuffer[DataPoint](capacity)
+final class CircularBufferTimeSeries(
+  override val interval: Duration,
+  capacity: Int
+) extends CircularBuffer[DataPoint](capacity)
     with TimeSeries
     with Seekable { self =>
 
-  override def append(dataPoint: DataPoint): Unit = write(dataPoint)
+  override def append(dp: DataPoint): Unit = write(dp)
+
+  override def write(dp: DataPoint): Unit =
+    if (dp.value != Value.Undefined) super.write(dp)
 
   override def start: Time = self.headOption match {
     case Some(dp) => dp.time
@@ -30,11 +36,7 @@ class CircularBufferTimeSeries(override val interval: Duration, capacity: Int)
     case _        => throw new IllegalStateException(s"No end in $this")
   }
 
-  override def indexAt(time: Time): Int = {
-    this.toIndexedSeq.search(DataPoint(time, 0))(DataPoint.timeOrdering) match {
-      case Searching.Found(idx)                     => idx
-      case Searching.InsertionPoint(idx) if idx > 0 => idx
-      case _ => -1 // special case at 0 index
-    }
-  }
+  override def indexAt(time: Time): Searching.SearchResult =
+    this.toIndexedSeq.search(DataPoint(time, 0))(DataPoint.timeOrdering)
+
 }

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/TimeSeriesTest.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/TimeSeriesTest.scala
@@ -8,11 +8,7 @@ class TimeSeriesTest extends Test with TimeSeriesBehaviors {
     nonEmptyTimeSeries(
       "DenseTimeSeries",
       { case TimeSeriesBehaviors.Input(interval, values) =>
-        new immutable.DenseTimeSeries(
-          interval,
-          values.head.time,
-          values.map(_.value)
-        )
+        immutable.DenseTimeSeries(interval, values)
       }
     )
   )
@@ -21,8 +17,7 @@ class TimeSeriesTest extends Test with TimeSeriesBehaviors {
     nonEmptyTimeSeries(
       "SparseTimeSeries",
       { case TimeSeriesBehaviors.Input(interval, values) =>
-        val (t, v) = values.unzip
-        new immutable.SparseTimeSeries(interval, t, v)
+        immutable.SparseTimeSeries(interval, values)
       }
     )
   )

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/immutable/BUILD.bazel
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/immutable/BUILD.bazel
@@ -1,0 +1,12 @@
+scala_test(
+    name = "immutable",
+    srcs = glob(["*.scala"]),
+    deps = [
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable",
+        "@maven//:com_twitter_util_core_2_13",
+        "@maven//:com_twitter_util_slf4j_api_2_13",
+        "@maven//:org_slf4j_slf4j_api",
+        "@testJars//:com_twitter_inject_core_2_13_tests",
+    ],
+)


### PR DESCRIPTION
### Problem

We have no support for undefined values, which results in
the `DenseTimeSeries` implementation only supporting a
fully populated series. This reduces the utility of the
`DenseTimeSeries` as a storage/wire representation of a
`TimeSeries`.

### Solution

Refactor the `DataPoint` class from a simple `Double` value
to use a `Value` type. A `Value` trait was chosen instead of
making the `DataPoint` generic in order to both improve or
maintain readability, but to also retain the ability to maintain
an `Ordering` for the `DataPoint` value.

Tests were added to verify consistent behavior across
`TimeSeries` implementations when faced with `Value.Undefined`.


### Result

This refactor has also simplified our `Searching` behavior
across implementations, as the common logic now exists in
our `TimeSeriesOps` implicits. The API surface for the
`TimeSeries` is starting to take shape.

Resolves #14 

Note: This code is not fully optimized or intended to be. I
think this will make a good example project for a benchmark
and profiling blog post.