### PR TITLE
timeseries4s: basic TimeSeries and Value operators

### DIFF
--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/TimeSeriesOps.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/TimeSeriesOps.scala
@@ -2,9 +2,11 @@ package dev.enbnt.timeseries
 
 import com.twitter.util.Time
 import dev.enbnt.timeseries.common.DataPoint
+import dev.enbnt.timeseries.common.DataPointOps._
 import dev.enbnt.timeseries.common.Seekable
 import dev.enbnt.timeseries.common.TimeSeriesLike
 import dev.enbnt.timeseries.common.Value
+import dev.enbnt.timeseries.common.Value._
 import scala.collection.Searching
 
 object TimeSeriesOps {
@@ -51,6 +53,66 @@ object TimeSeriesOps {
         case Searching.InsertionPoint(idx) if idx > 0 => idx
         case _ => -1 // special case at 0 index
       }
+
+    // TODO - lots and lots of scaladoc
+    // note - All TimeSeriesLike -> TimeSeriesLike operations will only
+    //        result in values at times that are defined in `ts` and also
+    //        exist in `other`
+
+    def +(other: TimeSeriesLike): TimeSeriesLike = applyOpTs(other)(_ + _)
+    def +(v: Value): TimeSeriesLike = applyOpValue(v)(_ + _)
+    def +(v: Float): TimeSeriesLike = ts + v.asValue
+    def +(v: Double): TimeSeriesLike = ts + v.asValue
+    def +(v: Int): TimeSeriesLike = ts + v.asValue
+    def +(v: Long): TimeSeriesLike = ts + v.asValue
+    def -(other: TimeSeriesLike): TimeSeriesLike = applyOpTs(other)(_ - _)
+    def -(v: Value): TimeSeriesLike = applyOpValue(v)(_ - _)
+    def -(v: Float): TimeSeriesLike = ts - v.asValue
+    def -(v: Double): TimeSeriesLike = ts - v.asValue
+    def -(v: Int): TimeSeriesLike = ts - v.asValue
+    def -(v: Long): TimeSeriesLike = ts - v.asValue
+    def *(other: TimeSeriesLike): TimeSeriesLike = applyOpTs(other)(_ * _)
+    def *(v: Value): TimeSeriesLike = applyOpValue(v)(_ * _)
+    def *(v: Float): TimeSeriesLike = ts * v.asValue
+    def *(v: Double): TimeSeriesLike = ts * v.asValue
+    def *(v: Int): TimeSeriesLike = ts * v.asValue
+    def *(v: Long): TimeSeriesLike = ts * v.asValue
+    def /(other: TimeSeriesLike): TimeSeriesLike = applyOpTs(other)(_ / _)
+    def /(v: Value): TimeSeriesLike = applyOpValue(v)(_ / _)
+    def /(v: Float): TimeSeriesLike = ts / v.asValue
+    def /(v: Double): TimeSeriesLike = ts / v.asValue
+    def /(v: Int): TimeSeriesLike = ts / v.asValue
+    def /(v: Long): TimeSeriesLike = ts / v.asValue
+
+    private[this] def applyOpTs(
+      ts2: TimeSeriesLike
+    )(f: (DataPoint, DataPoint) => DataPoint): TimeSeriesLike = {
+      require(
+        ts.interval == ts2.interval,
+        "TimeSeries with unmatched intervals cannot be added"
+      )
+      if (ts.isEmpty || ts2.isEmpty || ts.end < ts2.start || ts2.end < ts.start)
+        TimeSeries.empty()
+      else {
+        val data: Iterable[DataPoint] = ts.flatMap { dp =>
+          ts2.get(dp.time) match {
+            case Some(dp2) => Some(f(dp, dp2))
+            case _         => None
+          }
+        }
+        TimeSeries(ts.interval, data)
+      }
+    }
+
+    private[this] def applyOpValue(
+      v: Value
+    )(f: (DataPoint, Value) => DataPoint): TimeSeriesLike = {
+      if (ts.isEmpty || v == Value.Undefined) TimeSeries.empty()
+      else {
+        val data: Iterable[DataPoint] = ts.map(f(_, v))
+        TimeSeries(ts.interval, data)
+      }
+    }
   }
 
 }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/DataPoint.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/DataPoint.scala
@@ -18,10 +18,10 @@ private[timeseries] object DataPoint {
 }
 
 /**
- * A simple [[Time]] and [[Double value]] pairing.
+ * A simple [[Time]] and [[Value]] pairing.
  *
  * @param time
- *   The time at which the value was recorded
+ *   The time at which the [[value]] was recorded
  * @param value
  *   The measured value of that data associated with the given [[time]]
  */

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/DataPointOps.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/DataPointOps.scala
@@ -1,0 +1,49 @@
+package dev.enbnt.timeseries.common
+
+import dev.enbnt.timeseries.common.Value._
+
+object DataPointOps {
+
+  implicit class RichDataPoint(val dp: DataPoint) extends AnyVal {
+
+    def +(other: DataPoint): DataPoint = applyOpDp(other)(_ + _)
+    def +(v: Value): DataPoint = applyOpValue(v)(_ + _)
+    def +(f: Float): DataPoint = dp + f.asValue
+    def +(d: Double): DataPoint = dp + d.asValue
+    def +(i: Int): DataPoint = dp + i.asValue
+    def +(l: Long): DataPoint = dp + l.asValue
+
+    def -(other: DataPoint): DataPoint = applyOpDp(other)(_ - _)
+    def -(v: Value): DataPoint = applyOpValue(v)(_ - _)
+    def -(v: Float): DataPoint = dp - v.asValue
+    def -(v: Double): DataPoint = dp - v.asValue
+    def -(v: Int): DataPoint = dp - v.asValue
+    def -(v: Long): DataPoint = dp - v.asValue
+
+    def /(other: DataPoint): DataPoint = applyOpDp(other)(_ / _)
+    def /(v: Value): DataPoint = applyOpValue(v)(_ / _)
+    def /(v: Float): DataPoint = dp / v.asValue
+    def /(v: Double): DataPoint = dp / v.asValue
+    def /(v: Int): DataPoint = dp / v.asValue
+    def /(v: Long): DataPoint = dp / v.asValue
+
+    def *(other: DataPoint): DataPoint = applyOpDp(other)(_ * _)
+    def *(v: Value): DataPoint = applyOpValue(v)(_ * _)
+    def *(v: Float): DataPoint = dp * v.asValue
+    def *(v: Double): DataPoint = dp * v.asValue
+    def *(v: Int): DataPoint = dp * v.asValue
+    def *(v: Long): DataPoint = dp * v.asValue
+
+    private[this] def applyOpDp(
+      dp2: DataPoint
+    )(f: (Value, Value) => Value): DataPoint = {
+      require(dp.time == dp2.time)
+      applyOpValue(dp2.value)(f)
+    }
+    private[this] def applyOpValue(v: Value)(
+      f: (Value, Value) => Value
+    ): DataPoint = DataPoint(dp.time, f(dp.value, v))
+
+  }
+
+}

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Value.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Value.scala
@@ -1,8 +1,25 @@
 package dev.enbnt.timeseries.common
-import dev.enbnt.timeseries.common.Value.Undefined
 
 /** [[Value]] is a marker trait for Time Series value data. */
-sealed trait Value extends Any
+sealed trait Value extends Any {
+
+  /** A comparator between [[Value]] types priority */
+  def castPriority: Int
+
+  /** Convert [[Value v]] to [[this]] [[Value]] type */
+  def recast(v: Value): Value
+
+  def asInt: Int
+  def asLong: Long
+  def asFloat: Float
+  def asDouble: Double
+
+  def +(other: Value): Value
+  def -(other: Value): Value
+  def *(other: Value): Value
+  def /(other: Value): Value
+
+}
 
 object Value {
   implicit val ordering: Ordering[Value] = Ordering.by {
@@ -13,11 +30,169 @@ object Value {
     case Undefined    => Double.NaN
   }
 
-  case class FloatVal(value: Float) extends AnyVal with Value
-  case class DoubleVal(value: Double) extends AnyVal with Value
-  case class IntVal(value: Int) extends AnyVal with Value
-  case class LongVal(value: Long) extends AnyVal with Value
-  case object Undefined extends Value
+  // follow behavior of operating across int, long, double, and float
+  // types, while still supporting Undefined across all operations.
+  // this will take the type with priority amongst given values and
+  // re-cast the lower type to match (int -> long -> float -> double -> undefined)
+  private[this] def upcast(v1: Value, v2: Value)(
+    f: (Value, Value) => Value
+  ): Value = {
+    val diff = v1.castPriority - v2.castPriority
+    if (diff == 0) {
+      f(v1, v2)
+    } else if (diff > 0) {
+      f(v1, v1.recast(v2))
+    } else {
+      f(v2.recast(v1), v2)
+    }
+  }
+
+  case class FloatVal(value: Float) extends AnyVal with Value {
+    override def asInt: Int = value.toInt
+    override def asLong: Long = value.toLong
+    override def asFloat: Float = value
+    override def asDouble: Double = value.toDouble
+
+    override def +(other: Value): Value = other match {
+      case FloatVal(v) => FloatVal(value + v.value)
+      case _           => upcast(this, other)(_ + _)
+    }
+
+    override def -(other: Value): Value = other match {
+      case FloatVal(v) => FloatVal(value - v.value)
+      case _           => upcast(this, other)(_ - _)
+    }
+    override def *(other: Value): Value = other match {
+      case FloatVal(v) => FloatVal(value * v.value)
+      case _           => upcast(this, other)(_ * _)
+    }
+
+    override def /(other: Value): Value = other match {
+      case FloatVal(v) => FloatVal(value / v.value)
+      case _           => upcast(this, other)(_ / _)
+    }
+
+    override def castPriority: Int = 2
+
+    override def recast(v: Value): Value = FloatVal(v.asFloat)
+  }
+  case class DoubleVal(value: Double) extends AnyVal with Value {
+    override def asInt: Int = value.toInt
+    override def asLong: Long = value.toLong
+
+    override def asFloat: Float = value.toFloat
+
+    override def asDouble: Double = value
+
+    override def +(other: Value): Value = other match {
+      case DoubleVal(v) => DoubleVal(value + v.value)
+      case _            => upcast(this, other)(_ + _)
+    }
+
+    override def -(other: Value): Value = other match {
+      case DoubleVal(v) => DoubleVal(value - v.value)
+      case _            => upcast(this, other)(_ - _)
+    }
+
+    override def *(other: Value): Value = other match {
+      case DoubleVal(v) => DoubleVal(value * v.value)
+      case _            => upcast(this, other)(_ * _)
+    }
+
+    override def /(other: Value): Value = other match {
+      case DoubleVal(v) => DoubleVal(value / v.value)
+      case _            => upcast(this, other)(_ / _)
+    }
+
+    override def castPriority: Int = 3
+
+    override def recast(v: Value): Value = DoubleVal(v.asDouble)
+  }
+  case class IntVal(value: Int) extends AnyVal with Value {
+    override def asInt: Int = value
+    override def asLong: Long = value.toLong
+
+    override def asFloat: Float = value.toFloat
+
+    override def asDouble: Double = value.toDouble
+
+    override def +(other: Value): Value = other match {
+      case IntVal(v) => IntVal(value + v.value)
+      case _         => upcast(this, other)(_ + _)
+    }
+
+    override def -(other: Value): Value = other match {
+      case IntVal(v) => IntVal(value - v.value)
+      case _         => upcast(this, other)(_ - _)
+    }
+
+    override def *(other: Value): Value = other match {
+      case IntVal(v) => IntVal(value * v.value)
+      case _         => upcast(this, other)(_ * _)
+    }
+
+    override def /(other: Value): Value = other match {
+      case IntVal(v) => IntVal(value / v.value)
+      case _         => upcast(this, other)(_ / _)
+    }
+
+    override def castPriority: Int = 0
+
+    override def recast(v: Value): Value = IntVal(v.asInt)
+  }
+  case class LongVal(value: Long) extends AnyVal with Value {
+    override def asInt: Int = value.toInt
+    override def asLong: Long = value
+
+    override def asFloat: Float = value.toFloat
+
+    override def asDouble: Double = value.toDouble
+
+    override def +(other: Value): Value = other match {
+      case LongVal(v) => LongVal(value + v.value)
+      case _          => upcast(this, other)(_ + _)
+    }
+
+    override def -(other: Value): Value = other match {
+      case LongVal(v) => LongVal(value - v.value)
+      case _          => upcast(this, other)(_ - _)
+    }
+
+    override def *(other: Value): Value = other match {
+      case LongVal(v) => LongVal(value * v.value)
+      case _          => upcast(this, other)(_ * _)
+    }
+
+    override def /(other: Value): Value = other match {
+      case LongVal(v) => LongVal(value / v.value)
+      case _          => upcast(this, other)(_ / _)
+    }
+
+    override def castPriority: Int = 1
+
+    override def recast(v: Value): Value = LongVal(v.asLong)
+  }
+  case object Undefined extends Value {
+    override def asInt: Int = throw new IllegalStateException()
+
+    override def asLong: Long = throw new IllegalStateException()
+
+    override def asFloat: Float = Float.NaN
+
+    override def asDouble: Double = Double.NaN
+
+    override def +(other: Value): Value = this
+
+    override def -(other: Value): Value = this
+
+    override def *(other: Value): Value = this
+
+    override def /(other: Value): Value = this
+
+    override def castPriority: Int = Int.MaxValue
+
+    override def recast(v: Value): Value = this
+  }
 
   implicit class RichFloat(val value: Float) extends AnyVal {
     def asValue: Value = if (value.isNaN) Undefined else FloatVal(value)

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/common/BUILD.bazel
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/common/BUILD.bazel
@@ -1,0 +1,12 @@
+scala_test(
+    name = "common",
+    srcs = glob(["*.scala"]),
+    deps = [
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common",
+        "@maven//:com_twitter_util_core_2_13",
+        "@maven//:com_twitter_util_slf4j_api_2_13",
+        "@maven//:org_slf4j_slf4j_api",
+        "@testJars//:com_twitter_inject_core_2_13_tests",
+    ],
+)

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/common/DataPointOpsTest.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/common/DataPointOpsTest.scala
@@ -1,0 +1,261 @@
+package dev.enbnt.timeseries.common
+
+import com.twitter.inject.Test
+import com.twitter.util.Time
+import dev.enbnt.timeseries.common.DataPointOps._
+import dev.enbnt.timeseries.common.Value._
+
+class DataPointOpsTest extends Test {
+
+  private[this] val t = Time.now
+
+  test("DataPointOps#add two data points") {
+    // int + int
+    assert(DataPoint(t, 5) + DataPoint(t, 10) == DataPoint(t, 15))
+    // int + undefined
+    assert(
+      DataPoint(t, 5) + DataPoint(t, Value.Undefined) == DataPoint(
+        t,
+        Value.Undefined
+      )
+    )
+    // int + double
+    assert(DataPoint(t, 5) + DataPoint(t, 1.5d) == DataPoint(t, 6.5d))
+    // double + int
+    assert(DataPoint(t, 1.5d) + DataPoint(t, 5) == DataPoint(t, 6.5d))
+    // int + float
+    assert(DataPoint(t, 5) + DataPoint(t, 2.5f) == DataPoint(t, 7.5f))
+    // float + int
+    assert(DataPoint(t, 2.5f) + DataPoint(t, 5) == DataPoint(t, 7.5f))
+    // int + long
+    assert(DataPoint(t, 5) + DataPoint(t, 200L) == DataPoint(t, 205L))
+    // long + long
+    assert(DataPoint(t, 200L) + DataPoint(t, 500L) == DataPoint(t, 700L))
+    // long + int
+    assert(DataPoint(t, 200L) + DataPoint(t, 5) == DataPoint(t, 205L))
+    // long + float
+    assert(DataPoint(t, 200L) + DataPoint(t, 52f) == DataPoint(t, 252f))
+    // float + long
+    assert(DataPoint(t, 52f) + DataPoint(t, 200L) == DataPoint(t, 252f))
+    // long + double
+    assert(DataPoint(t, 200L) + DataPoint(t, 55d) == DataPoint(t, 255d))
+    // double + long
+    assert(DataPoint(t, 55d) + DataPoint(t, 200L) == DataPoint(t, 255d))
+    // float + float
+    assert(DataPoint(t, 12.5f) + DataPoint(t, 7.25f) == DataPoint(t, 19.75f))
+    // double + double
+    assert(
+      DataPoint(t, 55.12d) + DataPoint(t, 1.22d) == DataPoint(t, 55.12d + 1.22d)
+    )
+    // float + double
+    assert(DataPoint(t, 55.25f) + DataPoint(t, 25.25d) == DataPoint(t, 80.5d))
+    // double + float
+    assert(DataPoint(t, 25.25d) + DataPoint(t, 55.25f) == DataPoint(t, 80.5d))
+  }
+
+  test("DataPointOps#subtract two data points") {
+    // int - int
+    assert(DataPoint(t, 5) - DataPoint(t, 2) == DataPoint(t, 3))
+    // int - undefined
+    assert(
+      DataPoint(t, 5) - DataPoint(t, Value.Undefined) == DataPoint(
+        t,
+        Value.Undefined
+      )
+    )
+    // int - double
+    assert(DataPoint(t, 5) - DataPoint(t, 1.5d) == DataPoint(t, 3.5d))
+    // double - int
+    assert(DataPoint(t, 6.5d) - DataPoint(t, 5) == DataPoint(t, 1.5d))
+    // int - float
+    assert(DataPoint(t, 5) - DataPoint(t, 2.5f) == DataPoint(t, 2.5f))
+    // float - int
+    assert(DataPoint(t, 7.5f) - DataPoint(t, 5) == DataPoint(t, 2.5f))
+    // int - long
+    assert(DataPoint(t, 5) - DataPoint(t, 200L) == DataPoint(t, -195L))
+    // long - long
+    assert(DataPoint(t, 200L) - DataPoint(t, 500L) == DataPoint(t, -300L))
+    // long - int
+    assert(DataPoint(t, 200L) - DataPoint(t, 5) == DataPoint(t, 195L))
+    // long - float
+    assert(DataPoint(t, 200L) - DataPoint(t, 52.5f) == DataPoint(t, 147.5f))
+    // float - long
+    assert(DataPoint(t, 52.6f) - DataPoint(t, 20L) == DataPoint(t, 32.6f))
+    // long - double
+    assert(
+      DataPoint(t, 200L) - DataPoint(t, 55.33d) == DataPoint(t, 200L - 55.33d)
+    )
+    // double - long
+    assert(DataPoint(t, 55d) - DataPoint(t, 200L) == DataPoint(t, -145d))
+    // float - float
+    assert(DataPoint(t, 12.5f) - DataPoint(t, 7.25f) == DataPoint(t, 5.25f))
+    // double - double
+    assert(
+      DataPoint(t, 55.12d) - DataPoint(t, 1.22d) == DataPoint(t, 55.12d - 1.22d)
+    )
+    // float - double
+    assert(DataPoint(t, 55.25f) - DataPoint(t, 25.25d) == DataPoint(t, 30d))
+    // double - float
+    assert(DataPoint(t, 25.25d) - DataPoint(t, 55.25f) == DataPoint(t, -30d))
+  }
+
+  test("DataPointOps#multiply two data points") {
+    // int * int
+    assert(DataPoint(t, 5) * DataPoint(t, 2) == DataPoint(t, 10))
+    // int * undefined
+    assert(
+      DataPoint(t, 5) * DataPoint(t, Value.Undefined) == DataPoint(
+        t,
+        Value.Undefined
+      )
+    )
+    // int * double
+    assert(DataPoint(t, 5) * DataPoint(t, 1.5d) == DataPoint(t, 7.5))
+    // double * int
+    assert(DataPoint(t, -6.5d) * DataPoint(t, 5) == DataPoint(t, -32.5d))
+    // int * float
+    assert(DataPoint(t, 5) * DataPoint(t, 2.5f) == DataPoint(t, 12.5f))
+    // float * int
+    assert(DataPoint(t, 7.5f) * DataPoint(t, 5) == DataPoint(t, 37.5f))
+    // int * long
+    assert(DataPoint(t, 5) * DataPoint(t, 200L) == DataPoint(t, 1000L))
+    // long * long
+    assert(DataPoint(t, 200L) * DataPoint(t, 500L) == DataPoint(t, 100000L))
+    // long * int
+    assert(DataPoint(t, 200L) * DataPoint(t, 5) == DataPoint(t, 1000L))
+    // long * float
+    assert(DataPoint(t, 200L) * DataPoint(t, 52.5f) == DataPoint(t, 10500f))
+    // float * long
+    assert(DataPoint(t, 52.6f) * DataPoint(t, 20L) == DataPoint(t, 1052f))
+    // long * double
+    assert(
+      DataPoint(t, 200L) * DataPoint(t, 55.33d) == DataPoint(t, 200L * 55.33d)
+    )
+    // double * long
+    assert(DataPoint(t, 55d) * DataPoint(t, 200L) == DataPoint(t, 55d * 200L))
+    // float * float
+    assert(DataPoint(t, 12.5f) * DataPoint(t, 7.25f) == DataPoint(t, 90.625f))
+    // double * double
+    assert(
+      DataPoint(t, 55.12d) * DataPoint(t, 1.22d) == DataPoint(t, 55.12d * 1.22d)
+    )
+    // float * double
+    assert(
+      DataPoint(t, 55.25f) * DataPoint(t, 25.25d) == DataPoint(t, 1395.0625d)
+    )
+    // double * float
+    assert(
+      DataPoint(t, 25.25d) * DataPoint(t, 55.25f) == DataPoint(t, 1395.0625d)
+    )
+  }
+
+  test("DataPointOps#divide two data points") {
+    // int / int
+    assert(DataPoint(t, 10) / DataPoint(t, 2) == DataPoint(t, 5))
+    assert(DataPoint(t, 5) / DataPoint(t, 2) == DataPoint(t, 2))
+    // int / undefined
+    assert(
+      DataPoint(t, 5) / DataPoint(t, Value.Undefined) == DataPoint(
+        t,
+        Value.Undefined
+      )
+    )
+    // int / double
+    assert(DataPoint(t, 5) / DataPoint(t, 1.5d) == DataPoint(t, 5 / 1.5d))
+    // double / int
+    assert(DataPoint(t, -6.5d) / DataPoint(t, 5) == DataPoint(t, -6.5d / 5))
+    // int / float
+    assert(DataPoint(t, 5) / DataPoint(t, 2.5f) == DataPoint(t, 2f))
+    // float / int
+    assert(DataPoint(t, 7.5f) / DataPoint(t, 5) == DataPoint(t, 7.5f / 5))
+    // int / long
+    assert(DataPoint(t, 5) / DataPoint(t, 200L) == DataPoint(t, 0L))
+    // long / long
+    assert(DataPoint(t, 200L) / DataPoint(t, 500L) == DataPoint(t, 0L))
+    // long / int
+    assert(DataPoint(t, 200L) / DataPoint(t, 5) == DataPoint(t, 40L))
+    // long / float
+    assert(
+      DataPoint(t, 200L) / DataPoint(t, 52.5f) == DataPoint(t, 200L / 52.5f)
+    )
+    // float / long
+    assert(DataPoint(t, 52.6f) / DataPoint(t, 20L) == DataPoint(t, 52.6f / 20L))
+    // long / double
+    assert(
+      DataPoint(t, 200L) / DataPoint(t, 55.33d) == DataPoint(t, 200L / 55.33d)
+    )
+    // double / long
+    assert(DataPoint(t, 55d) / DataPoint(t, 200L) == DataPoint(t, 55d / 200L))
+    // float / float
+    assert(
+      DataPoint(t, 12.5f) / DataPoint(t, 7.25f) == DataPoint(t, 12.5f / 7.25f)
+    )
+    // double / double
+    assert(
+      DataPoint(t, 55.12d) / DataPoint(t, 1.22d) == DataPoint(t, 55.12d / 1.22d)
+    )
+    // float / double
+    assert(
+      DataPoint(t, 55.25f) / DataPoint(t, 25.25d) == DataPoint(
+        t,
+        55.25f / 25.25d
+      )
+    )
+    // double / float
+    assert(
+      DataPoint(t, 25.25d) / DataPoint(t, 55.25f) == DataPoint(
+        t,
+        25.25d / 55.25f
+      )
+    )
+  }
+
+  test("DataPointOps#add value to data point") {
+    assert(DataPoint(t, 5) + 5.asValue == DataPoint(t, 10))
+    assert(DataPoint(t, 5) + 5 == DataPoint(t, 10))
+    assert(DataPoint(t, 5) + 5L.asValue == DataPoint(t, 10L))
+    assert(DataPoint(t, 5) + 5L == DataPoint(t, 10L))
+    assert(DataPoint(t, 5) + 5f.asValue == DataPoint(t, 10f))
+    assert(DataPoint(t, 5) + 5f == DataPoint(t, 10f))
+    assert(DataPoint(t, 5) + 5d.asValue == DataPoint(t, 10d))
+    assert(DataPoint(t, 5) + 5d == DataPoint(t, 10d))
+    assert(DataPoint(t, 5) + Value.Undefined == DataPoint(t, Value.Undefined))
+  }
+
+  test("DataPointOps#subtract value from data point") {
+    assert(DataPoint(t, 5) - 5.asValue == DataPoint(t, 0))
+    assert(DataPoint(t, 5) - 5 == DataPoint(t, 0))
+    assert(DataPoint(t, 5) - 5L.asValue == DataPoint(t, 0L))
+    assert(DataPoint(t, 5) - 5L == DataPoint(t, 0L))
+    assert(DataPoint(t, 5) - 5f.asValue == DataPoint(t, 0f))
+    assert(DataPoint(t, 5) - 5f == DataPoint(t, 0f))
+    assert(DataPoint(t, 5) - 5d.asValue == DataPoint(t, 0d))
+    assert(DataPoint(t, 5) - 5d == DataPoint(t, 0d))
+    assert(DataPoint(t, 5) - Value.Undefined == DataPoint(t, Value.Undefined))
+  }
+
+  test("DataPointOps#multiply value to data point") {
+    assert(DataPoint(t, 5) * 5.asValue == DataPoint(t, 25))
+    assert(DataPoint(t, 5) * 5 == DataPoint(t, 25))
+    assert(DataPoint(t, 5) * 5L.asValue == DataPoint(t, 25L))
+    assert(DataPoint(t, 5) * 5L == DataPoint(t, 25L))
+    assert(DataPoint(t, 5) * 5f.asValue == DataPoint(t, 25f))
+    assert(DataPoint(t, 5) * 5f == DataPoint(t, 25f))
+    assert(DataPoint(t, 5) * 5d.asValue == DataPoint(t, 25d))
+    assert(DataPoint(t, 5) * 5d == DataPoint(t, 25d))
+    assert(DataPoint(t, 5) * Value.Undefined == DataPoint(t, Value.Undefined))
+  }
+
+  test("DataPointOps#divide value to data point") {
+    assert(DataPoint(t, 5) / 5.asValue == DataPoint(t, 1))
+    assert(DataPoint(t, 5) / 5 == DataPoint(t, 1))
+    assert(DataPoint(t, 5) / 5L.asValue == DataPoint(t, 1L))
+    assert(DataPoint(t, 5) / 5L == DataPoint(t, 1L))
+    assert(DataPoint(t, 5) / 5f.asValue == DataPoint(t, 1f))
+    assert(DataPoint(t, 5) / 5f == DataPoint(t, 1f))
+    assert(DataPoint(t, 5) / 5d.asValue == DataPoint(t, 1d))
+    assert(DataPoint(t, 5) / 5d == DataPoint(t, 1d))
+    assert(DataPoint(t, 5) / Value.Undefined == DataPoint(t, Value.Undefined))
+  }
+
+}


### PR DESCRIPTION
### Problem

Our `TimeSeries` only supports basic `range(start, end)` and
`get()` operations. We probably want to support basic arithmetic
operations for a TimeSeries and its values.

### Solution

Introduce arithmetic operations (`+`, `-`, `*`, `/`) that can work
across `Value`, `DataPoint`, and `TimeSeries` classes. These
support our specific `Value` types in order to retain consistent
behavior when encountering an `Undefined` value type across
all `TimeSeries` implementations and `Value` types. If these
were simple numeric types, undefined `Float` and `Double`
values would cast to a zero value for both `Int` and `Long`, which
is not desirable. For now we are loosely following the arithmetic
behavior of our operators as defined via [Prometheus](https://prometheus.io/docs/prometheus/latest/querying/operators/).

### Result

We can now do basic arithmetic operations on a `TimeSeries`.

Note: This is still in a draft-ish form and the documentation is
not nailed down yet. I am expecting further evolution and refactoring
and would like to avoid more stale doc maintenance until this
has more time to simmer.