### PR TITLE
timeseries4s: introduce comparison operators

### DIFF
--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/TimeSeriesOps.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/TimeSeriesOps.scala
@@ -59,6 +59,7 @@ object TimeSeriesOps {
     //        result in values at times that are defined in `ts` and also
     //        exist in `other`
 
+    /* Arithmetic Operators */
     def +(other: TimeSeriesLike): TimeSeriesLike = applyOpTs(other)(_ + _)
     def +(v: Value): TimeSeriesLike = applyOpValue(v)(_ + _)
     def +(v: Float): TimeSeriesLike = ts + v.asValue
@@ -84,6 +85,81 @@ object TimeSeriesOps {
     def /(v: Int): TimeSeriesLike = ts / v.asValue
     def /(v: Long): TimeSeriesLike = ts / v.asValue
 
+    /* Comparison Operators */
+    def <(other: TimeSeriesLike): TimeSeriesLike =
+      applyCompareOpTs(other)(DataPoint.valueOrdering.lt)
+    def <(v: Value): TimeSeriesLike =
+      applyCompareOpValue(v)(Value.ordering.lt)
+    def <(v: Float): TimeSeriesLike = ts < v.asValue
+    def <(v: Double): TimeSeriesLike = ts < v.asValue
+    def <(v: Int): TimeSeriesLike = ts < v.asValue
+    def <(v: Long): TimeSeriesLike = ts < v.asValue
+
+    def >(other: TimeSeriesLike): TimeSeriesLike =
+      applyCompareOpTs(other)(DataPoint.valueOrdering.gt)
+    def >(v: Value): TimeSeriesLike =
+      applyCompareOpValue(v)(Value.ordering.gt)
+    def >(v: Float): TimeSeriesLike = ts > v.asValue
+    def >(v: Double): TimeSeriesLike = ts > v.asValue
+    def >(v: Int): TimeSeriesLike = ts > v.asValue
+    def >(v: Long): TimeSeriesLike = ts > v.asValue
+
+    def <=(other: TimeSeriesLike): TimeSeriesLike =
+      applyCompareOpTs(other)(DataPoint.valueOrdering.lteq)
+
+    def <=(v: Value): TimeSeriesLike =
+      applyCompareOpValue(v)(Value.ordering.lteq)
+
+    def <=(v: Float): TimeSeriesLike = ts <= v.asValue
+
+    def <=(v: Double): TimeSeriesLike = ts <= v.asValue
+
+    def <=(v: Int): TimeSeriesLike = ts <= v.asValue
+
+    def <=(v: Long): TimeSeriesLike = ts <= v.asValue
+
+    def >=(other: TimeSeriesLike): TimeSeriesLike =
+      applyCompareOpTs(other)(DataPoint.valueOrdering.gteq)
+
+    def >=(v: Value): TimeSeriesLike =
+      applyCompareOpValue(v)(Value.ordering.gteq)
+
+    def >=(v: Float): TimeSeriesLike = ts >= v.asValue
+
+    def >=(v: Double): TimeSeriesLike = ts >= v.asValue
+
+    def >=(v: Int): TimeSeriesLike = ts >= v.asValue
+
+    def >=(v: Long): TimeSeriesLike = ts >= v.asValue
+
+    def ===(other: TimeSeriesLike): TimeSeriesLike =
+      applyCompareOpTs(other)(DataPoint.valueOrdering.equiv)
+
+    def ===(v: Value): TimeSeriesLike =
+      applyCompareOpValue(v)(Value.ordering.equiv)
+
+    def ===(v: Float): TimeSeriesLike = ts === v.asValue
+
+    def ===(v: Double): TimeSeriesLike = ts === v.asValue
+
+    def ===(v: Int): TimeSeriesLike = ts === v.asValue
+
+    def ===(v: Long): TimeSeriesLike = ts === v.asValue
+
+    def !==(other: TimeSeriesLike): TimeSeriesLike =
+      applyCompareOpTs(other)(!DataPoint.valueOrdering.equiv(_, _))
+
+    def !==(v: Value): TimeSeriesLike =
+      applyCompareOpValue(v)(!Value.ordering.equiv(_, _))
+
+    def !==(v: Float): TimeSeriesLike = ts !== v.asValue
+
+    def !==(v: Double): TimeSeriesLike = ts !== v.asValue
+
+    def !==(v: Int): TimeSeriesLike = ts !== v.asValue
+
+    def !==(v: Long): TimeSeriesLike = ts !== v.asValue
+
     private[this] def applyOpTs(
       ts2: TimeSeriesLike
     )(f: (DataPoint, DataPoint) => DataPoint): TimeSeriesLike = {
@@ -104,12 +180,44 @@ object TimeSeriesOps {
       }
     }
 
+    private[this] def applyCompareOpTs(
+      ts2: TimeSeriesLike
+    )(f: (DataPoint, DataPoint) => Boolean): TimeSeriesLike = {
+      require(
+        ts.interval == ts2.interval,
+        "TimeSeries with unmatched intervals cannot be added"
+      )
+      if (ts.isEmpty || ts2.isEmpty || ts.end < ts2.start || ts2.end < ts.start)
+        TimeSeries.empty()
+      else {
+        val data: Iterable[DataPoint] = ts.flatMap { dp =>
+          ts2.get(dp.time) match {
+            case Some(dp2) => if (f(dp, dp2)) Some(dp) else None
+            case _         => None
+          }
+        }
+        TimeSeries(ts.interval, data)
+      }
+    }
+
     private[this] def applyOpValue(
       v: Value
     )(f: (DataPoint, Value) => DataPoint): TimeSeriesLike = {
       if (ts.isEmpty || v == Value.Undefined) TimeSeries.empty()
       else {
         val data: Iterable[DataPoint] = ts.map(f(_, v))
+        TimeSeries(ts.interval, data)
+      }
+    }
+
+    private[this] def applyCompareOpValue(
+      v: Value
+    )(f: (Value, Value) => Boolean): TimeSeriesLike = {
+      if (ts.isEmpty || v == Value.Undefined) TimeSeries.empty()
+      else {
+        val data: Iterable[DataPoint] = ts.filter { dp =>
+          f(dp.value, v)
+        }
         TimeSeries(ts.interval, data)
       }
     }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/TimeSeriesLike.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/TimeSeriesLike.scala
@@ -13,8 +13,10 @@ trait TimeSeriesLike extends Iterable[DataPoint] {
   override def equals(obj: Any): Boolean = obj match {
     case ts: TimeSeriesLike =>
       this.eq(ts) ||
-      (this.interval == ts.interval && this.start == ts.start && this.end == ts.end && this.iterator
-        .sameElements(ts))
+      (this.interval == ts.interval
+        && this.start == ts.start
+        && this.end == ts.end
+        && iterator.sameElements(ts.iterator))
     case _ =>
       false
   }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable/TimeSeries.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable/TimeSeries.scala
@@ -93,9 +93,9 @@ private[timeseries] final class SparseTimeSeries private (
   val interval: Duration,
   times: IndexedSeq[Time],
   values: IndexedSeq[Value]
-) extends TimeSeries
-    with Seekable
-    with IndexedSeq[DataPoint] { self =>
+) extends IndexedSeq[DataPoint]
+    with TimeSeries
+    with Seekable { self =>
 
   override def start: Time = times.head
   override def end: Time = times.last
@@ -150,9 +150,9 @@ private[timeseries] final class DenseTimeSeries private (
   val interval: Duration,
   val start: Time,
   values: IndexedSeq[Value]
-) extends TimeSeries
-    with Seekable
-    with IndexedSeq[DataPoint] { self =>
+) extends IndexedSeq[DataPoint]
+    with TimeSeries
+    with Seekable { self =>
 
   override def apply(i: Int): DataPoint = DataPoint(timeAt(i), values(i))
 
@@ -196,5 +196,7 @@ private[timeseries] final class DenseTimeSeries private (
   }
 
   override def iterator: Iterator[DataPoint] = view.iterator
+
+  override def className = "DenseTimeSeries"
 
 }

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/TimeSeriesBehaviors.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/TimeSeriesBehaviors.scala
@@ -577,6 +577,362 @@ trait TimeSeriesBehaviors { this: AnyFunSuite =>
       assert(t1 / Value.Undefined == TimeSeries.empty())
     }
 
+    test(s"$label#less than") {
+      val interval = 1.second
+      val start = Time.now.floor(interval) - 5.seconds
+
+      val t1: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, Value.Undefined),
+            DataPoint(start + 1.second, Value.Undefined),
+            DataPoint(start + 2.seconds, 6),
+            DataPoint(start + 3.seconds, Value.Undefined),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, Value.Undefined)
+          )
+        )
+      )
+
+      val t2: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, 1),
+            DataPoint(start + 1.second, 2),
+            DataPoint(start + 2.seconds, 3),
+            DataPoint(start + 3.seconds, 4),
+            DataPoint(start + 4.seconds, 5),
+            DataPoint(start + 5.seconds, 6)
+          )
+        )
+      )
+
+      assert(t1 < t2 == TimeSeries.empty())
+
+      assert(
+        t1 < 10 == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(
+        t1 < 10L == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(
+        t1 < 10f == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(
+        t1 < 10d == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(t1 < Value.Undefined == TimeSeries.empty())
+
+    }
+
+    test(s"$label#greater than") {
+      val interval = 1.second
+      val start = Time.now.floor(interval) - 5.seconds
+
+      val t1: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, Value.Undefined),
+            DataPoint(start + 1.second, Value.Undefined),
+            DataPoint(start + 2.seconds, 6),
+            DataPoint(start + 3.seconds, Value.Undefined),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, Value.Undefined)
+          )
+        )
+      )
+
+      val t2: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, 1),
+            DataPoint(start + 1.second, 2),
+            DataPoint(start + 2.seconds, 3),
+            DataPoint(start + 3.seconds, 4),
+            DataPoint(start + 4.seconds, 5),
+            DataPoint(start + 5.seconds, 6)
+          )
+        )
+      )
+
+      // IndexedSeq(DataPoint(2023-03-03 18:25:58 +0000,IntVal(6)), DataPoint(2023-03-03 18:26:00 +0000,IntVal(15)))
+      // did not equal
+      // CircularBuffer(DataPoint(2023-03-03 18:25:58 +0000,IntVal(6)), DataPoint(2023-03-03 18:26:00 +0000,IntVal(15)))
+      assert(t1 > t2 == t1)
+
+      assert(
+        t1 > 10 == TimeSeries(interval, Seq(DataPoint(start + 4.seconds, 15)))
+      )
+      assert(
+        t1 > 10L == TimeSeries(interval, Seq(DataPoint(start + 4.seconds, 15)))
+      )
+      assert(
+        t1 > 10f == TimeSeries(interval, Seq(DataPoint(start + 4.seconds, 15)))
+      )
+      assert(
+        t1 > 10d == TimeSeries(interval, Seq(DataPoint(start + 4.seconds, 15)))
+      )
+      assert(t1 > Value.Undefined == TimeSeries.empty())
+
+    }
+
+    test(s"$label#less than or equal to") {
+      val interval = 1.second
+      val start = Time.now.floor(interval) - 5.seconds
+
+      val t1: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, Value.Undefined),
+            DataPoint(start + 1.second, Value.Undefined),
+            DataPoint(start + 2.seconds, 6),
+            DataPoint(start + 3.seconds, 2),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, Value.Undefined)
+          )
+        )
+      )
+
+      val t2: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, 1),
+            DataPoint(start + 1.second, 2),
+            DataPoint(start + 2.seconds, 3),
+            DataPoint(start + 3.seconds, 4),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, 6)
+          )
+        )
+      )
+
+      assert(
+        t1 <= t2 == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 3.seconds, 2), DataPoint(start + 4.seconds, 15))
+        )
+      )
+
+      assert(
+        t1 <= 6 == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 3.seconds, 2))
+        )
+      )
+      assert(
+        t1 <= 6L == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 3.seconds, 2))
+        )
+      )
+      assert(
+        t1 <= 6f == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 3.seconds, 2))
+        )
+      )
+      assert(
+        t1 <= 6d == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 3.seconds, 2))
+        )
+      )
+      assert(t1 <= Value.Undefined == TimeSeries.empty())
+
+    }
+
+    test(s"$label#greater than or equal to") {
+      val interval = 1.second
+      val start = Time.now.floor(interval) - 5.seconds
+
+      val t1: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, Value.Undefined),
+            DataPoint(start + 1.second, Value.Undefined),
+            DataPoint(start + 2.seconds, 6),
+            DataPoint(start + 3.seconds, 2),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, Value.Undefined)
+          )
+        )
+      )
+
+      val t2: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, 1),
+            DataPoint(start + 1.second, 2),
+            DataPoint(start + 2.seconds, 3),
+            DataPoint(start + 3.seconds, 4),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, 6)
+          )
+        )
+      )
+
+      assert(
+        t1 >= t2 == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 4.seconds, 15))
+        )
+      )
+
+      assert(
+        t1 >= 6 == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(
+        t1 >= 6L == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(
+        t1 >= 6f == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(
+        t1 >= 6d == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(t1 >= Value.Undefined == TimeSeries.empty())
+
+    }
+
+    test(s"$label#equal to") {
+      val interval = 1.second
+      val start = Time.now.floor(interval) - 5.seconds
+
+      val t1: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, Value.Undefined),
+            DataPoint(start + 1.second, Value.Undefined),
+            DataPoint(start + 2.seconds, 6),
+            DataPoint(start + 3.seconds, 2),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, Value.Undefined)
+          )
+        )
+      )
+
+      val t2: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, 1),
+            DataPoint(start + 1.second, 2),
+            DataPoint(start + 2.seconds, 3),
+            DataPoint(start + 3.seconds, 4),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, 6)
+          )
+        )
+      )
+
+      assert(
+        t1 === t2 == TimeSeries(interval, Seq(DataPoint(start + 4.seconds, 15)))
+      )
+
+      assert(
+        t1 === 6 == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(
+        t1 === 6L == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(
+        t1 === 6f == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(
+        t1 === 6d == TimeSeries(interval, Seq(DataPoint(start + 2.seconds, 6)))
+      )
+      assert(t1 === Value.Undefined == TimeSeries.empty())
+
+    }
+
+    test(s"$label#not equal to") {
+      val interval = 1.second
+      val start = Time.now.floor(interval) - 5.seconds
+
+      val t1: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, Value.Undefined),
+            DataPoint(start + 1.second, Value.Undefined),
+            DataPoint(start + 2.seconds, 6),
+            DataPoint(start + 3.seconds, 2),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, Value.Undefined)
+          )
+        )
+      )
+
+      val t2: TimeSeries = ts(
+        TimeSeriesBehaviors.Input(
+          interval,
+          Array(
+            DataPoint(start, 1),
+            DataPoint(start + 1.second, 2),
+            DataPoint(start + 2.seconds, 3),
+            DataPoint(start + 3.seconds, 4),
+            DataPoint(start + 4.seconds, 15),
+            DataPoint(start + 5.seconds, 6)
+          )
+        )
+      )
+
+      assert(
+        (t1 !== t2) == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 2.seconds, 6), DataPoint(start + 3.seconds, 2))
+        )
+      )
+
+      assert(
+        (t1 !== 6) == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 3.seconds, 2), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(
+        (t1 !== 6L) == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 3.seconds, 2), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(
+        (t1 !== 6f) == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 3.seconds, 2), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert(
+        (t1 !== 6d) == TimeSeries(
+          interval,
+          Seq(DataPoint(start + 3.seconds, 2), DataPoint(start + 4.seconds, 15))
+        )
+      )
+      assert((t1 !== Value.Undefined) == TimeSeries.empty())
+
+    }
+
   }
 
   def emptyTimeSeries(ts: => TimeSeries): Unit = {


### PR DESCRIPTION
### Problem

We have introduced basic arithmetic support for
time series data, but we do not support comparison
operations (`>`, `<`, `<=`, `>=`, `!=`, `==`) with
`TimeSeries`.

### Solution

Introduce operators `>`, `<`, `<=`, `>=`, `!==`,
`===` for comparing `TimeSeries` to other
`TimeSeries`, `Value`, or value type primitives.
Any comparison that operates on a `Undefined`
value will result in an empty time series.

Unlike arithmetic operators, comparison operators
will not re-cast the `Value` type based on the
comparison type. It will simply act as a filter.

### Result

We have some basic support for comparison and
filtering of time series based on new comparison
operators.