### PR TITLE
timeseries4s: introduce data source & tagging

### DIFF
--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/BUILD.bazel
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "datasource",
+    srcs = glob(["*.scala"]),
+    visibility = ["//visibility:public"],
+    exports = [
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/util",
+        "@maven//:com_twitter_util_core_2_13",
+    ],
+    deps = [
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/util",
+        "@maven//:com_twitter_util_core_2_13",
+    ],
+)

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/DataSource.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/DataSource.scala
@@ -1,0 +1,16 @@
+package dev.enbnt.timeseries.datasource
+
+import com.twitter.util.Duration
+import com.twitter.util.Time
+import dev.enbnt.timeseries.common.TimeSeriesLike
+
+// This is ONLY a data layer and it is not concerned with Query DSL/semantics
+private[timeseries] trait DataSource {
+  def apply(
+    metric: String,
+    start: Time,
+    end: Time,
+    interval: Duration,
+    tags: Map[String, String] = Map.empty
+  ): Iterable[TimeSeriesLike]
+}

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/InMemoryDataSource.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/InMemoryDataSource.scala
@@ -1,0 +1,79 @@
+package dev.enbnt.timeseries.datasource
+
+import com.twitter.util.Duration
+import com.twitter.util.Time
+import dev.enbnt.timeseries.common.DataPoint
+import dev.enbnt.timeseries.common.TimeSeriesLike
+import dev.enbnt.timeseries.mutable
+import dev.enbnt.timeseries.mutable.CircularBufferTimeSeries
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+/**
+ * A bounded in-memory [[DataSource]] implementation.
+ *
+ * @param interval
+ *   The [[Duration interval]] of each underlying [[TimeSeriesLike time series]]
+ * @param tsMaxSize
+ *   The maximum size of each underlying [[TimeSeriesLike time series]]
+ *
+ * @note
+ *   This class is intended to be used as a basic, local testing utility and is
+ *   not intended for large-scale production use.
+ */
+private[timeseries] final class InMemoryDataSource(
+  interval: Duration,
+  tsMaxSize: Int = 512
+) extends DataSource {
+
+  require(
+    tsMaxSize > 0,
+    "InMemoryDataSource must have a maximum time series size > 0"
+  )
+
+  private[this] val data
+    : scala.collection.mutable.Map[TagSet, mutable.TimeSeries] =
+    new ConcurrentHashMap[TagSet, mutable.TimeSeries].asScala
+
+  def append(
+    label: String,
+    dataPoint: DataPoint,
+    tags: Map[String, String] = Map.empty
+  ): Unit = {
+    // each tag permutation results in a new time series to track
+    tags.toSet.subsets().foreach { tags =>
+      val ts = data.getOrElseUpdate(
+        TagSet(label, tags),
+        new CircularBufferTimeSeries(interval, tsMaxSize)
+      )
+
+      // TODO - CircularBufferTimeSeries is not thread-safe, but our TagSet mapping is
+      ts synchronized {
+        ts.append(dataPoint)
+      }
+    }
+  }
+
+  def clear(): Unit = data.clear()
+
+  override def apply(
+    metric: String,
+    start: Time,
+    end: Time,
+    interval: Duration,
+    tags: Map[String, String] = Map.empty
+  ): Iterable[TimeSeriesLike] = {
+    if (interval != this.interval) {
+      Iterable.empty
+    } else {
+      val tagSet: Set[(String, String)] =
+        if (tags.isEmpty) Set.empty else tags.toSet
+
+      data.get(TagSet(metric, tagSet)) match {
+        case Some(ts) => Iterable.single(ts)
+        case _        => Iterable.empty
+      }
+    }
+
+  }
+}

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/TagSet.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource/TagSet.scala
@@ -1,0 +1,12 @@
+package dev.enbnt.timeseries.datasource
+
+/**
+ * A mapping key that associates a metric label and its tag key/value set
+ *
+ * @note
+ *   This is not an optimized structure
+ */
+private[datasource] final case class TagSet(
+  metric: String,
+  tags: Set[(String, String)]
+)

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable/TimeSeries.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable/TimeSeries.scala
@@ -3,6 +3,7 @@ package dev.enbnt.timeseries.mutable
 import com.twitter.util.Duration
 import com.twitter.util.Time
 import dev.enbnt.timeseries.common.DataPoint
+import dev.enbnt.timeseries.common.DataPointOps._
 import dev.enbnt.timeseries.common.Seekable
 import dev.enbnt.timeseries.common.TimeSeriesLike
 import dev.enbnt.timeseries.common.Value
@@ -21,7 +22,14 @@ final class CircularBufferTimeSeries(
     with TimeSeries
     with Seekable { self =>
 
-  override def append(dp: DataPoint): Unit = write(dp)
+  override def append(dp: DataPoint): Unit = lastOption match {
+    case Some(ldp) if dp.time == ldp.time => // we will sum the values
+      val dp2 = dp + ldp
+      if (dp2.value != Value.Undefined) write(size - 1, dp2)
+    case Some(ldp) if dp.time < ldp.time =>
+      () // ignore the write, it's too late
+    case _ => write(dp)
+  }
 
   override def write(dp: DataPoint): Unit =
     if (dp.value != Value.Undefined) super.write(dp)
@@ -39,4 +47,6 @@ final class CircularBufferTimeSeries(
   override def indexAt(time: Time): Searching.SearchResult =
     this.toIndexedSeq.search(DataPoint(time, 0))(DataPoint.timeOrdering)
 
+  /** @inheritdoc */
+  override def className = "CircularBufferTimeSeries"
 }

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/util/CircularBuffer.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/util/CircularBuffer.scala
@@ -61,8 +61,6 @@ import scala.reflect.ClassTag
  *   The starting offset of the read index
  * @param writeIdx
  *   The starting offset of the write index
- * @param count
- *   The number of elements present within the buffer.
  * @tparam T
  *   The type of elements of contained within the buffer
  */
@@ -70,8 +68,7 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
   val capacity: Int,
   elems: Array[T],
   var readIdx: Int,
-  var writeIdx: Int,
-  var count: Int
+  var writeIdx: Int
 ) extends Iterable[T]
     with IterableOps[T, CircularBuffer, CircularBuffer[T]]
     with IterableFactoryDefaults[T, CircularBuffer]
@@ -83,13 +80,10 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
     s"CircularBuffer capacity must be > 0, but received '$capacity'"
   )
 
-  def this(capacity: Int) = this(
-    capacity,
-    elems = Array.ofDim[T](capacity),
-    readIdx = 0,
-    writeIdx = 0,
-    count = 0
-  )
+  private[this] def count = math.min(writeIdx - readIdx + 1, capacity)
+
+  def this(capacity: Int) =
+    this(capacity, elems = Array.ofDim[T](capacity), readIdx = 0, writeIdx = -1)
 
   /**
    * Consume the value at the current read index, modifying the state of the
@@ -100,9 +94,8 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
   def read(): T = {
     if (isEmpty)
       throw new IllegalStateException("Cannot read ahead of written value")
-    val v = elems(readIdx)
-    readIdx = incr(readIdx)
-    count -= 1
+    val v = elems(readIdx % capacity)
+    readIdx += 1
     v
   }
 
@@ -127,8 +120,7 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
       throw new IllegalStateException(
         s"Read offset '$offset' was >= buffer size of '$size'"
       )
-    val idx = incr(readIdx, offset)
-    elems(idx)
+    elems((readIdx + offset) % capacity)
   }
 
   /**
@@ -136,13 +128,19 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
    * buffer.
    */
   def write(value: T): Unit = {
-    elems(writeIdx) = value
-    writeIdx = incr(writeIdx)
-    count += 1
-    if (count > capacity) {
-      readIdx = incr(writeIdx)
-      count -= 1
+    writeIdx += 1
+    elems(writeIdx % capacity) = value
+    if (writeIdx - readIdx == capacity) {
+      readIdx += 1
     }
+  }
+
+  def write(offset: Int, value: T): Unit = {
+    if (offset >= size)
+      throw new IllegalStateException(
+        "Cannot write to an offset that hasn't been written to"
+      )
+    elems((readIdx + offset) % capacity) = value
   }
 
   /**
@@ -155,10 +153,6 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
   def write(values: T*): Unit = {
     values.foreach(write)
   }
-
-  // Increment an index by a specified amount, accounting for loops in the buffer space
-  private[this] def incr(idx: Int, amount: Int = 1): Int =
-    Math.abs((idx + amount) % capacity)
 
   /**
    * @inheritdoc
@@ -209,8 +203,7 @@ private[timeseries] class CircularBuffer[T: ClassTag] private (
       capacity,
       elems = newElems,
       readIdx = self.readIdx,
-      writeIdx = self.writeIdx,
-      count = count
+      writeIdx = self.writeIdx
     )
     val ret = cb.asInstanceOf[CircularBuffer[B]]
     ret.write(elem)

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/datasource/BUILD.bazel
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/datasource/BUILD.bazel
@@ -1,0 +1,14 @@
+scala_test(
+    name = "datasource",
+    srcs = glob(["*.scala"]),
+    deps = [
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/mutable",
+        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/datasource",
+        "@maven//:com_twitter_util_core_2_13",
+        "@maven//:com_twitter_util_slf4j_api_2_13",
+        "@maven//:org_slf4j_slf4j_api",
+        "@testJars//:com_twitter_inject_core_2_13_tests",
+    ],
+)

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/datasource/InMemoryDataSourceTest.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/datasource/InMemoryDataSourceTest.scala
@@ -1,0 +1,209 @@
+package dev.enbnt.timeseries.datasource
+
+import com.twitter.conversions.DurationOps._
+import com.twitter.inject.Test
+import com.twitter.util.Time
+import dev.enbnt.timeseries.common.DataPoint
+import dev.enbnt.timeseries.immutable.TimeSeries
+
+class InMemoryDataSourceTest extends Test {
+
+  test("InMemoryDataSource#store and retrieve") {
+    val interval = 1.second
+    val now = Time.now.floor(interval)
+    val store = new InMemoryDataSource(interval)
+    store.append(
+      "requests",
+      DataPoint(now, 5),
+      tags = Map("method" -> "GET", "success" -> "true", "host" -> "localhost")
+    )
+    store.append(
+      "requests",
+      DataPoint(now, 5),
+      tags = Map("method" -> "GET", "success" -> "false", "host" -> "localhost")
+    )
+    store.append(
+      "requests",
+      DataPoint(now + 1.second, 10),
+      tags = Map("method" -> "GET", "success" -> "true", "host" -> "localhost")
+    )
+    store.append(
+      "requests",
+      DataPoint(now + 1.second, 10),
+      tags = Map("method" -> "GET", "success" -> "false", "host" -> "localhost")
+    )
+    store.append(
+      "requests",
+      DataPoint(now + 1.second, 3),
+      tags = Map("method" -> "PUT", "success" -> "true", "host" -> "localhost")
+    )
+
+    val queryResult = store.apply("requests", now, now + 1.second, interval)
+    assert(queryResult.nonEmpty)
+    assert(queryResult.size == 1)
+    queryResult.head.iterator.sameElements(
+      TimeSeries(
+        interval = interval,
+        data = Array(DataPoint(now, 10), DataPoint(now + 1.second, 23))
+      )
+    )
+
+    val queryResult2 = store.apply(
+      "requests",
+      now,
+      now + 1.second,
+      interval,
+      Map("method" -> "GET")
+    )
+    assert(queryResult2.nonEmpty)
+    assert(queryResult2.size == 1)
+    queryResult2.head.iterator.sameElements(
+      TimeSeries(
+        interval = interval,
+        data = Array(DataPoint(now, 10), DataPoint(now + 1.second, 20))
+      )
+    )
+
+    val queryResult3 = store.apply(
+      "requests",
+      now,
+      now + 1.second,
+      interval,
+      Map("method" -> "GET", "success" -> "false")
+    )
+    assert(queryResult3.nonEmpty)
+    assert(queryResult3.size == 1)
+    queryResult3.head.iterator.sameElements(
+      TimeSeries(
+        interval = interval,
+        data = Array(DataPoint(now, 5), DataPoint(now + 1.second, 10))
+      )
+    )
+
+    val queryResult4 = store.apply(
+      "requests",
+      now,
+      now + 1.second,
+      interval,
+      Map("method" -> "PUT")
+    )
+    assert(queryResult4.nonEmpty)
+    assert(queryResult4.size == 1)
+    queryResult4.head.iterator.sameElements(
+      TimeSeries(
+        interval = interval,
+        data = Array(DataPoint(now + 1.second, 3))
+      )
+    )
+
+    assert(
+      store
+        .apply(
+          "requests",
+          now,
+          now + 1.second,
+          interval,
+          Map("method" -> "POST", "success" -> "true")
+        )
+        .isEmpty
+    )
+  }
+
+  test("InMemoryDataSource#ring buffer loops when max size hit") {
+    val interval = 1.second
+    val now = Time.now.floor(interval)
+    val store = new InMemoryDataSource(interval, 4)
+
+    assert(store.apply("requests", Time.Bottom, Time.Top, interval).isEmpty)
+
+    (0 until 4).foreach { i =>
+      store.append("requests", DataPoint(now + i.seconds, i))
+    }
+
+    val queryResult = store.apply("requests", Time.Bottom, Time.Top, interval)
+    assert(queryResult.nonEmpty)
+    assert(queryResult.size == 1)
+    assert(queryResult.head.size == 4)
+    assert(
+      queryResult.head == TimeSeries(
+        interval,
+        Array(
+          DataPoint(now, 0),
+          DataPoint(now + 1.second, 1),
+          DataPoint(now + 2.seconds, 2),
+          DataPoint(now + 3.seconds, 3)
+        )
+      )
+    )
+
+    store.append("requests", DataPoint(now + 4.seconds, 4))
+
+    val queryResult2 = store.apply("requests", Time.Bottom, Time.Top, interval)
+    assert(queryResult2.nonEmpty)
+    assert(queryResult2.size == 1)
+    assert(queryResult2.head.size == 4)
+    assert(
+      queryResult2.head == TimeSeries(
+        interval,
+        Array(
+          DataPoint(now + 1.second, 1),
+          DataPoint(now + 2.seconds, 2),
+          DataPoint(now + 3.seconds, 3),
+          DataPoint(now + 4.seconds, 4)
+        )
+      )
+    )
+
+    store.append("requests", DataPoint(now + 5.seconds, 5))
+
+    val queryResult3 = store.apply("requests", Time.Bottom, Time.Top, interval)
+    assert(queryResult2.nonEmpty)
+    assert(queryResult2.size == 1)
+    assert(queryResult2.head.size == 4)
+    assert(
+      queryResult3.head == TimeSeries(
+        interval,
+        Array(
+          DataPoint(now + 2.seconds, 2),
+          DataPoint(now + 3.seconds, 3),
+          DataPoint(now + 4.seconds, 4),
+          DataPoint(now + 5.seconds, 5)
+        )
+      )
+    )
+
+  }
+
+  test("InMemoryDataSource#clear()") {
+    val interval = 1.second
+    val now = Time.now.floor(interval)
+    val store = new InMemoryDataSource(interval, 4)
+
+    assert(store.apply("requests", Time.Bottom, Time.Top, interval).isEmpty)
+
+    (0 until 4).foreach { i =>
+      store.append("requests", DataPoint(now + i.seconds, i))
+    }
+
+    val queryResult = store.apply("requests", Time.Bottom, Time.Top, interval)
+    assert(queryResult.nonEmpty)
+    assert(queryResult.size == 1)
+    assert(queryResult.head.size == 4)
+    assert(
+      queryResult.head == TimeSeries(
+        interval,
+        Array(
+          DataPoint(now, 0),
+          DataPoint(now + 1.second, 1),
+          DataPoint(now + 2.seconds, 2),
+          DataPoint(now + 3.seconds, 3)
+        )
+      )
+    )
+
+    store.clear()
+    assert(store.apply("requests", Time.Bottom, Time.Top, interval).isEmpty)
+
+  }
+
+}


### PR DESCRIPTION
### Problem

We have the ability to use basic functions against
a `TimeSeries` construct, but lack the ability to
fetch or operate across multiple `TimeSeries`
associated with a metric label or tags.

### Solution

We introduce a `DataSource` trait and a basic
`InMemoryDataSource` implementation which
support retrieving `TimeSeries` data across
multiple dimensions (cardinality).

### Result

This is a basic start to the API, but we can continue
to evolve and improve things.