### PR TITLE
update doc with coverage command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ bazel-*
 .settings/
 # Maven
 target/
+
+# Code Coverage Reports
+genhtml/

--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ is an example [Finatra](https://www.github.com/twitter/finatra)
 project, which illustrates some of the built-in distributed trace annotation
 testing utilities. See the [Distributed Tracing and Testing](https://www.enbnt.dev/posts/tracing-and-testing/)
 blog post for a deeper look into this project.
+
+## Command Reference
+
+To generate a code coverage report (requires `lcov` and `genhtml` to be installed):
+
+``` 
+$ bazel coverage --cache_test_results=no\
+    --combined_report=lcov \
+    --coverage_report_generator="@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main" \
+    --instrumentation_filter="-/src/test/scala[/:]" \
+    //...
+$ genhtml --output genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat"
+$ open genhtml/index.html   
+```


### PR DESCRIPTION
Bazel code coverage commands don't work out of the box (result in empty dat files), so let's document an actual working example.