### PR TITLE
Bazel: custom scala toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,9 +97,13 @@ rules_proto_dependencies()
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+# default scala toolchain, commented out in favor of custom chain
+#load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+#
+#scala_register_toolchains()
 
-scala_register_toolchains()
+# Register a custom, local tool chain
+register_toolchains("//toolchains:my_scala_toolchain")
 
 # optional: setup ScalaTest toolchain and dependencies
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Value.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common/Value.scala
@@ -23,10 +23,10 @@ sealed trait Value extends Any {
 
 object Value {
   implicit val ordering: Ordering[Value] = Ordering.by {
-    case FloatVal(v)  => v
+    case FloatVal(v)  => v.toDouble
     case DoubleVal(v) => v
-    case LongVal(v)   => v
-    case IntVal(v)    => v
+    case LongVal(v)   => v.toDouble
+    case IntVal(v)    => v.toDouble
     case Undefined    => Double.NaN
   }
 

--- a/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable/TimeSeries.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/immutable/TimeSeries.scala
@@ -10,6 +10,7 @@ import scala.collection.IndexedSeqOps
 import scala.collection.IndexedSeqView
 import scala.collection.Searching
 import scala.collection.Searching.SearchResult
+import scala.collection.immutable.ArraySeq
 
 sealed trait TimeSeries extends TimeSeriesLike
 
@@ -141,7 +142,7 @@ object DenseTimeSeries {
       }
     }
 
-    new DenseTimeSeries(interval, start, ar)
+    new DenseTimeSeries(interval, start, ArraySeq.unsafeWrapArray(ar))
   }
 
 }

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/common/BUILD.bazel
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/common/BUILD.bazel
@@ -2,7 +2,6 @@ scala_test(
     name = "common",
     srcs = glob(["*.scala"]),
     deps = [
-        "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries",
         "//timeseries/timeseries4s/timeseries-core/src/main/scala/dev/enbnt/timeseries/common",
         "@maven//:com_twitter_util_core_2_13",
         "@maven//:com_twitter_util_slf4j_api_2_13",

--- a/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/util/CircularBufferTest.scala
+++ b/timeseries/timeseries4s/timeseries-core/src/test/scala/dev/enbnt/timeseries/util/CircularBufferTest.scala
@@ -1,7 +1,6 @@
 package dev.enbnt.timeseries.util
 
 import com.twitter.inject.Test
-import scala.collection.IterableOnce.iterableOnceExtensionMethods
 
 class CircularBufferTest extends Test {
 

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "setup_scala_toolchain")
+
+setup_scala_toolchain(
+    name = "my_scala_toolchain",
+    dependency_tracking_unused_deps_patterns = ["-@maven//:com_twitter_util_slf4j_api_2_13"],
+    scala_compile_classpath = [
+        "@maven//:org_scala_lang_scala_compiler",
+        "@maven//:org_scala_lang_scala_library",
+        "@maven//:org_scala_lang_scala_reflect",
+    ],
+    scala_library_classpath = [
+        "@maven//:org_scala_lang_scala_library",
+        "@maven//:org_scala_lang_scala_reflect",
+    ],
+    scala_macro_classpath = [
+        "@maven//:org_scala_lang_scala_library",
+        "@maven//:org_scala_lang_scala_reflect",
+    ],
+    scalacopts = [
+        "-Ywarn-dead-code",
+        "-Ywarn-value-discard",
+        "-deprecation",
+        "-Xfatal-warnings",
+        "-explaintypes",
+        "-feature",
+        "-unchecked",
+        "-Ywarn-unused:imports",  # Warn if an import selector is not referenced.
+        "-Ywarn-unused:privates",  # Warn if a private member is unused.
+    ],
+    strict_deps_mode = "error",
+    unused_dependency_checker_mode = "error",
+    visibility = ["//visibility:public"],
+)

--- a/tracing-and-testing/src/main/scala/dev/enbnt/example/ExampleHttpServer.scala
+++ b/tracing-and-testing/src/main/scala/dev/enbnt/example/ExampleHttpServer.scala
@@ -28,5 +28,6 @@ class ExampleHttpServer extends HttpServer {
       .filter[HttpNackFilter[Request]]
       .add[ExampleController]
       .add[LifecycleController]
+    ()
   }
 }


### PR DESCRIPTION
Introduce a custom bazel toolchain for scala projects that will by default enforce a cleaner workspace via unused dependency tracking and failure on compiler warnings.